### PR TITLE
fix logic to show pleading on tenants gather

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/shared.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/shared.yml
@@ -713,7 +713,7 @@ subquestion: |
   % else:
   The tenant's name and address should be included as a Defendant.
   % endif
-  % if tenant_got_summons and petition_available and len(users)==1:
+  % if tenant_got_summons and petition_available:
   
   [FILE ComplaintCaptionDefendant.png, 100%]
   


### PR DESCRIPTION
fix logic to show pleading on tenants gather

Fix #295

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [ ] Requested review from Mia or Quinten
* [X] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
