### PR TITLE
Update `id: late fees explanation` and late fee defense

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -185,8 +185,7 @@ code: |
       excessive_rent
     if late_fees_assessed and trial_court.circuit == 21:
       petition_separates_nonrent
-  if late_fees_assessed:
-    late_fees_penalty
+  late_fees_assessed
   if eviction_reason["nonpayment of rent"]:
     petition_states_demand_made
     landlord_problems_section

--- a/docassemble/MOHUDEvictionProject/data/questions/defense_logic.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/defense_logic.yml
@@ -348,7 +348,8 @@ content: |
 #    field: relied_on_false_promises
 #    datatype: yesnoradio
 ---
-id: late fees defense logic
+id: late fees defense logic for has_written_lease
+if: has_written_lease
 code: |
   if late_fees_assessed and (late_fees_penalty or ((not late_fees_lease_provision) or late_fee_doesnt_comply_with_lease)):
     defense_liquidated_damages_late_fees = True
@@ -359,6 +360,17 @@ depends on:
   - late_fees_penalty
   - late_fees_lease_provision
   - late_fee_doesnt_comply_with_lease
+---
+id: late fees defense logic for not has_written_lease
+if: not has_written_lease
+code: |
+  if late_fees_assessed and late_fees_penalty:
+    defense_liquidated_damages_late_fees = True
+  else:
+    defense_liquidated_damages_late_fees = False
+depends on:
+  - late_fees_assessed
+  - late_fees_penalty
 ---
 id: late fees
 question: |
@@ -399,14 +411,13 @@ fields:
     show if: late_fees_assessed
   - label: |
       Is there a part of the {lease} that allows the landlord to charge the late fee?
-      % if has_written_lease == False:
-      You can answer no if you don't have a written lease.
-      % endif
     field: late_fees_lease_provision
     datatype: yesnomaybe
     show if: 
       variable: late_fees_assessed
       is: True
+      code: |
+        has_written_lease
   - label: |
       Do the late fees charged by the landlord comply with the lease provision?
       % if has_written_lease == False:
@@ -414,7 +425,11 @@ fields:
       % endif
     field: late_fee_doesnt_comply_with_lease
     datatype: noyesmaybe
-    show if: late_fees_lease_provision
+    show if: 
+      variable: late_fees_lease_provision
+      is: True
+      code: |
+        has_written_lease
 ---
 id: cqe breach logic
 comment: |

--- a/docassemble/MOHUDEvictionProject/data/questions/defense_logic.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/defense_logic.yml
@@ -364,13 +364,15 @@ depends on:
 id: late fees defense logic for not has_written_lease
 if: not has_written_lease
 code: |
-  if late_fees_assessed and late_fees_penalty:
+  if late_fees_assessed and not no_written_lease_any_written_late_fees:
     defense_liquidated_damages_late_fees = True
+    late_fees_penalty = False
+    late_fees_lease_provision = False
   else:
     defense_liquidated_damages_late_fees = False
 depends on:
   - late_fees_assessed
-  - late_fees_penalty
+  - no_written_lease_any_written_late_fees
 ---
 id: late fees
 question: |
@@ -388,6 +390,19 @@ fields:
       % endif
     field: late_fees_assessed
     datatype: yesnoradio
+  - label: |
+      % if person_answering == "tenant":
+      Did your landlord give you anything **in writing** that said they would charge late fees?
+      % else: 
+      Did the tenant's landlord give them anything **in writing** that said the landlord would charge late fees?
+      % endif
+    field: no_written_lease_any_written_late_fees
+    datatype: yesnomaybe
+    show if: 
+      variable: late_fees_assessed
+      is: True
+      code: |
+        not has_written_lease
   - note: |
       <h2 class="h4">Was the amount the landlord charged "fair"?</h2>
       It is up to a judge to decide if the late fee is "fair". But if the late fee is
@@ -399,7 +414,11 @@ fields:
       The fee may be too high.
       
       In some counties, more than $5 per day is considered too high.
-    show if: late_fees_assessed
+    show if: 
+      variable: late_fees_assessed
+      is: True
+      code: |
+        has_written_lease
   - label: |
       % if person_answering == "tenant":
       Is the late fee more than a fair amount to cover the landlord's cost?
@@ -408,7 +427,11 @@ fields:
       % endif
     field: late_fees_penalty
     datatype: yesnomaybe
-    show if: late_fees_assessed
+    show if: 
+      variable: late_fees_assessed
+      is: True
+      code: |
+        has_written_lease
   - label: |
       Is there a part of the {lease} that allows the landlord to charge the late fee?
     field: late_fees_lease_provision
@@ -420,9 +443,6 @@ fields:
         has_written_lease
   - label: |
       Do the late fees charged by the landlord comply with the lease provision?
-      % if has_written_lease == False:
-      You can answer no if you don't have a written lease.
-      % endif
     field: late_fee_doesnt_comply_with_lease
     datatype: noyesmaybe
     show if: 


### PR DESCRIPTION
`id: late fees explanation` - conditional language in question can be changed to ask if tenant has written lease first 

Fix #318

Requesting review from at least @tobyfey to confirm defense `defense_liquidated_damages_late_fees` 

<Type out your reasons for this PR>

<Add links to any solved or related issues here>

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested review from Mia or Quinten **+ Toby**
* [X] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
