### PR TITLE
fixed problem with end_accordion

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/review.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/review.yml
@@ -2240,7 +2240,7 @@ review:
     show if: not defense_failure_to_terminate
   - raw html: |
       ${ start_accordion('Tenant denies that Tenant violated the terms of the lease or that the claimed violation is a material breach') }
-    show if: not defense_failure_to_terminate
+    show if: not defense_ud_did_not_violate_lease
   - Edit:
       - defense_no_breach
       - recompute:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.MOHUDEvictionProject',
       url='https://motenanthelp.org/',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.AssemblyLine>=2.28.0'],
+      install_requires=['docassemble.AssemblyLine>=2.28.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MOHUDEvictionProject/', package='docassemble.MOHUDEvictionProject'),
      )


### PR DESCRIPTION
<Type out your reasons for this PR>

On the review screen, the continue button was hidden behind Eviction Defenses Not Included, A start_accordion had a show if with the wrong variable.


<Add links to any solved or related issues here>

fix #557 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [x] Manually tested to ensure my PR is working
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [x] Requested review from Mia or Quinten
* [ ] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
