### PR TITLE
removed petition_available from logic for defense_rent_pleadings_requ…

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/defense_logic.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/defense_logic.yml
@@ -116,7 +116,6 @@ id: rent pleadings requirement logic
 depends on:
   - eviction_reason
   - tenant_got_summons
-  - petition_available
   - petition_alleges_nonrent
   - petition_states_rent_amount
   - lease_attached
@@ -127,7 +126,7 @@ depends on:
   - petition_separates_nonrent
   - has_written_lease
 code: |
-  if eviction_reason["nonpayment of rent"] and tenant_got_summons and petition_available:
+  if eviction_reason["nonpayment of rent"] and tenant_got_summons:
     if petition_alleges_nonrent or not petition_states_rent_amount or (not has_written_lease and not petition_states_terms_of_lease) or (has_written_lease and not lease_attached and not petition_states_terms_of_lease) or not petition_states_rent_periods or not petition_states_demand_made or (trial_court.circuit == 21 and not petition_separates_nonrent):
       defense_rent_pleading_requirement = True
     else:
@@ -138,11 +137,10 @@ code: |
 id: lease not attached logic
 depends on:
   - tenant_got_summons
-  - petition_available
   - lease_attached
   - has_written_lease
 code: |
-  if tenant_got_summons and petition_available:
+  if tenant_got_summons:
     if has_written_lease and not lease_attached:
       defense_lease_not_attached = True
     else:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.MOHUDEvictionProject',
       url='https://motenanthelp.org/',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.AssemblyLine>=2.28.0'],
+      install_requires=['docassemble.AssemblyLine>=2.28.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MOHUDEvictionProject/', package='docassemble.MOHUDEvictionProject'),
      )


### PR DESCRIPTION
…irement and defense_lease_not_attached

I don't think defenses should be conditioned on the question "Do you have a copy of the Landlord's Petition available?"  There is no other variables that are conditioned on petition_available

<Add links to any solved or related issues here>
fix #560 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [x] Manually tested to ensure my PR is working
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [x] Requested review from Mia or Quinten
* [ ] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
