### PR TITLE
fixed formatting and logic in motion helper warning

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/file_a_motion.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/file_a_motion.yml
@@ -50,7 +50,7 @@ code: |
   if motion_list['motion_to_set_aside_judgment']: 
     final_judgment
   
-  if (motion_list['motion_to_dismiss'] and (not has_written_lease or not lease_attached or not eviction_reason["nonpayment of rent"])) or (motion_list['motion_to_set_aside_judgment'] and (judgment_date_more_than_30 or not final_judgment)):
+  if (motion_list['motion_to_dismiss'] and (not has_written_lease or lease_attached or not eviction_reason["nonpayment of rent"])) or (motion_list['motion_to_set_aside_judgment'] and (judgment_date_more_than_30 or not final_judgment)):
     warning_kickout_loop
   
   trial_court.name
@@ -253,12 +253,13 @@ question: |
   The tenant may not want to {file} this motion
   % endif
 subquestion: |
-  % if motion_list['motion_to_dismiss'] and (not has_written_lease or not lease_attached or not eviction_reason["nonpayment of rent"]):
+  % if motion_list['motion_to_dismiss'] and (not has_written_lease or lease_attached or not eviction_reason["nonpayment of rent"]):
   You selected to fill out a Motion to Dismiss or For a More Definite Statement. To file this motion, it should be true that: 
   
   1. Your ladlord is evicting you for nonpayment of rent;
   2. You have a written lease; AND
-  3. The lease was attached to the Landlord's petition when it was delivered to you.
+  3. The lease was not attached to the Landlord's petition when it was delivered to you.
+  
   % endif
   % if motion_list['motion_to_set_aside_judgment'] and (not final_judgment or judgment_date_more_than_30):
   You selected to fill out a Motion to Set Aside Judgment. To file this motion, it should be true that: 


### PR DESCRIPTION
<Type out your reasons for this PR>

Fixed formatting in warning in motion tester, and noticed the logic and instructions were backwards - a motion to dismiss is appropriate when the lease was NOT attached to the petition, not when it was attached

<Add links to any solved or related issues here>

close #552 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [x] Manually tested to ensure my PR is working
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [x] Requested review from Mia or Quinten
* [ ] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
