### PR TITLE
added notice of hearing doc blocks, code for motions_for_hearing used…

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -68,7 +68,9 @@ code: |
     if customize_discovery_choice == "customize_discovery":
       customize_discovery_requests
       review_discovery_requests
-    
+  
+  motions_for_hearing
+  
   set_progress(90)
   signpost_service_of_process
   nav.set_section("section_eviction_answer_download")  
@@ -507,6 +509,19 @@ code: |
 ---
 code: |
   motion_to_shorten_time_attachment.enabled = wants_discovery and not original_hearing_date_past
+---
+id: add notice of hearing if any motions enabled
+code: |
+  notice_of_hearing_attachment.enabled = motion_to_shorten_time_attachment.enabled or eviction_motion_for_leave_attachment.enabled or eviction_motion_to_continue_attachment.enabled
+---
+code: |
+  motions_for_hearing = list()
+  if motion_to_shorten_time_attachment.enabled:
+    motions_for_hearing.append("Motion to Shorten Time")
+  if eviction_motion_for_leave_attachment.enabled:
+    motions_for_hearing.append("Motion for Leave to File Responsive Pleadings")
+  if eviction_motion_to_continue_attachment.enabled:
+    motions_for_hearing.append("Motion to Continue")
 ---
 id: eviction answer determination code
 code: |

--- a/docassemble/MOHUDEvictionProject/data/questions/file_a_motion.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/file_a_motion.yml
@@ -862,11 +862,23 @@ attachment:
 ---
 objects:
   - motion_to_set_aside_attachment: ALDocument.using(title="File a Motion to Set Aside Judgment", filename="motion_to_set_aside.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - motion_to_shorten_time_attachment: ALDocument.using(title="File a Motion to Shorten Time", filename="motion_to_shorten_time.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - motion_to_dismiss_attachment: ALDocument.using(title="File a Motion to Dismiss", filename="motion_to_dismiss.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - motion_for_leave_to_file_attachment: ALDocument.using(title="File a Motion for Leave to File Responsive Pleadings", filename="motion_for_leave_to_file_answer.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - motion_to_elevate_security_attachment: ALDocument.using(title="File a Motion to Elevate Security", filename="motion_to_elevate_security.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - notice_of_hearing_attachment: ALDocument.using(title="File a Notice of Hearing", filename="notice_of_hearing.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - file_a_motion_helper_next_steps_attachment: ALDocument.using(title="Next Steps to File a Motion", filename="next_steps.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
 ---
 objects:

--- a/docassemble/MOHUDEvictionProject/data/questions/shared.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/shared.yml
@@ -917,6 +917,13 @@ attachment:
     skip undefined: True
     docx template file: motion_to_shorten_time.docx
 ---
+attachment:
+  - name: notice of hearing
+    filename: notice_of_hearing.docx     
+    variable name: notice_of_hearing_attachment[i]       
+    skip undefined: True
+    docx template file: notice_of_hearing.docx
+---
 id: preview eviction_defender
 question: |
   % if person_answering == "tenant":
@@ -1026,14 +1033,27 @@ progress: 100
 ---
 objects:
   - eviction_defender_post_interview_instructions: ALDocument.using(title="Instructions", filename="eviction_helper_next_steps.docx", enabled=True, has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - eviction_motion_to_continue_attachment: ALDocument.using(title="Postpone your eviction hearing", filename="eviction_motion_to_continue.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - eviction_answer_attachment: ALDocument.using(title="Answer and Affirmative Defenses", filename="answer_defenses.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - eviction_motion_for_leave_attachment: ALDocument.using(title="Motion for Leave to File Responsive Pleadings", filename="motion_for_leave_to_file.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - eviction_discovery_attachment: ALDocument.using(title="Discovery", filename="Discovery.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
   - motion_to_shorten_time_attachment: ALDocument.using(title="File a Motion to Shorten Time", filename="motion_to_shorten_time.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
 ---
 objects:
-  - al_user_bundle: ALDocumentBundle.using(elements=[eviction_defender_post_interview_instructions,eviction_motion_to_continue_attachment,eviction_answer_attachment,eviction_motion_for_leave_attachment,motion_to_shorten_time_attachment,eviction_discovery_attachment], filename="eviction_helper.docx_package.pdf", title="All forms to download for your records", enabled=True)
+  - notice_of_hearing_attachment: ALDocument.using(title="File a Notice of Hearing", filename="notice_of_hearing.docx", has_addendum=False, default_overflow_message=AL_DEFAULT_OVERFLOW_MESSAGE)
+---
+objects:
+  - al_user_bundle: ALDocumentBundle.using(elements=[eviction_defender_post_interview_instructions,eviction_motion_to_continue_attachment,eviction_answer_attachment,eviction_motion_for_leave_attachment,motion_to_shorten_time_attachment,eviction_discovery_attachment,notice_of_hearing_attachment], filename="eviction_helper.docx_package.pdf", title="All forms to download for your records", enabled=True)
   - al_court_bundle: ALDocumentBundle.using(elements=attachment_list_court, filename="eviction_helper.docx_package.pdf", title="All forms to download for your records", enabled=True)
 ---
 template: about_page_contents


### PR DESCRIPTION
… in doc, and cleaned object blocks

<Type out your reasons for this PR>

The Notice of Hearing needed to be added to EDDE because it is appropriate for the package any time a motion is generated.  (Are instructions needed?  I'll add a note to the next steps issue #450 

<Add links to any solved or related issues here>
Fix #540 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [ ] Manually tested to ensure my PR is working
* [ ] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [ ] Requested review from Mia or Quinten
* [ ] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
