### PR TITLE
Changed download screen on motion filer to new court dictionary

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/court_information.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/court_information.yml
@@ -37,7 +37,7 @@ code: |
     if "schedule" in county_dictionary[trial_court.county]["courts"][0].keys():
       trial_court.schedule = county_dictionary[trial_court.county]["courts"][0]["schedule"]
     else:
-      trial_court.address.schedule = None
+      trial_court.schedule = None
   else:
     trial_court.building_name = county_dictionary[trial_court.county]["courts"][int(trial_court.location_number)]["name"]
     trial_court.address.address = county_dictionary[trial_court.county]["courts"][int(trial_court.location_number)]["address"]

--- a/docassemble/MOHUDEvictionProject/data/questions/court_information.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/court_information.yml
@@ -15,6 +15,7 @@ code: |
       trial_court.circuit = county_dictionary[trial_court.county]['circuit']
   if len(county_dictionary[trial_court.county]["courts"]) == 1:
     trial_court.location_name = None
+    potential_courts = list()
   else:
     potential_courts = list()
     for index in range(len(county_dictionary[trial_court.county]["courts"])):

--- a/docassemble/MOHUDEvictionProject/data/questions/file_a_motion.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/file_a_motion.yml
@@ -927,7 +927,14 @@ subquestion: |
     % endif
     * Go to the court and file the forms at the clerk's office.
   
-  ${ county_dictionary[trial_court.county]['court_address_and_operating_hours'] }
+    ${ trial_court.building_name }
+      
+    ${ trial_court.address.on_one_line() }
+      
+    % if trial_court.schedule is not None:
+    ${ trial_court.schedule }
+    % endif
+  
   
   ###Deadline to deliver and file the forms###
   


### PR DESCRIPTION
<Type out your reasons for this PR>

File a Motion interview had a bug on the download screen because of references to the previous  county_dictionary.  I updated it with the same court information in the main eviction interview.

<Add links to any solved or related issues here>

Mentioned in #574 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [x] Manually tested to ensure my PR is working
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [x] Requested review from Mia or Quinten
* [ ] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
