### PR TITLE
Added right to counsel question when user selects that they are an at…

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -55,6 +55,7 @@ code: |
   store_variables_snapshot(
       persistent=True,
       data={
+          "is_right_to_counsel": is_right_to_counsel,
           "zip": showifdef("users[0].address.zip"),
           "reached_interview_end": True,
       },

--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -55,8 +55,10 @@ code: |
   store_variables_snapshot(
       persistent=True,
       data={
-          "is_right_to_counsel": is_right_to_counsel,
+          "is_right_to_counsel": showifdef ("is_right_to_counsel"),
           "zip": showifdef("users[0].address.zip"),
+          "city": showifdef("users[0].address.city"),
+          "county": showifdef("users[0].address.county"),
           "reached_interview_end": True,
       },
   )
@@ -263,7 +265,8 @@ subquestion: |
   % else:
   The tenant got the Summons and Petition in the following ways:
   % for method in method_of_summons_service.true_values():
-   - method_of_summons_service_text[method]
+  
+   - ${ method_of_summons_service_text[method] }
     
   % endfor
   % endif

--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -46,21 +46,27 @@ code: |
 mandatory: True
 code: |
   al_intro_screen
+  store_variables_snapshot(persistent=True, data={"start_time": start_time(), "reached_interview_end": False})
   eviction_defender_intro
   document_order
-
-  # Store anonymous data for analytics / statistics
   nav.set_section("review_eviction_answer")
   review_eviction_answer
   store_variables_snapshot(
-      persistent=True,
-      data={
-          "is_right_to_counsel": showifdef ("is_right_to_counsel"),
-          "zip": showifdef("users[0].address.zip"),
-          "city": showifdef("users[0].address.city"),
-          "county": showifdef("users[0].address.county"),
-          "reached_interview_end": True,
-      },
+    persistent=True,
+    data={
+        "start_time": start_time(),
+        "person_answering": showifdef("person_answering"),
+        "is_right_to_counsel": showifdef("is_right_to_counsel"),
+        "posting_warning": showifdef("posting_warning"),
+        "recommend_filing_answer": showifdef("recommend_filing_answer"),
+        "zip": showifdef("users[0].address.zip"),
+        "city": showifdef("users[0].address.city"),
+        "county": showifdef("users[0].address.county"),
+        "user_information_time": snapshot_user_information_time,
+        "case_information_time": snapshot_case_information_time,
+        "review_time": snapshot_review_time,
+        "reached_interview_end": False
+    },
   )
   
   nav.set_section("section_eviction_discovery")
@@ -71,8 +77,26 @@ code: |
     if customize_discovery_choice == "customize_discovery":
       customize_discovery_requests
       review_discovery_requests
-    
   set_progress(90)
+  store_variables_snapshot(
+      persistent=True,
+      data={
+          "start_time": start_time(),
+          "person_answering": showifdef("person_answering"),
+          "is_right_to_counsel": showifdef("is_right_to_counsel"),
+          "posting_warning": showifdef("posting_warning"),
+          "recommend_filing_answer": showifdef("recommend_filing_answer"),
+          "zip": showifdef("users[0].address.zip"),
+          "city": showifdef("users[0].address.city"),
+          "county": showifdef("users[0].address.county"),
+          "user_information_time": snapshot_user_information_time,
+          "case_information_time": snapshot_case_information_time,
+          "review_time": snapshot_review_time,
+          "discovery_time": snapshot_discovery_time,
+          "assembled_documents": assembled_documents,
+          "reached_interview_end": False,
+      },
+  )
   signpost_service_of_process
   nav.set_section("section_eviction_answer_download")  
   signature_date
@@ -83,7 +107,39 @@ code: |
 
   al_user_wants_reminders
   set_progress(100)
+  store_variables_snapshot(
+      persistent=True,
+      data={
+          "start_time": start_time(),
+          "person_answering": showifdef("person_answering"),
+          "is_right_to_counsel": showifdef("is_right_to_counsel"),
+          "posting_warning": showifdef("posting_warning"),
+          "recommend_filing_answer": showifdef("recommend_filing_answer"),
+          "zip": showifdef("users[0].address.zip"),
+          "city": showifdef("users[0].address.city"),
+          "county": showifdef("users[0].address.county"),
+          "user_information_time": snapshot_user_information_time,
+          "case_information_time": snapshot_case_information_time,
+          "review_time": snapshot_review_time,
+          "discovery_time": snapshot_discovery_time,
+          "assembled_documents": assembled_documents,
+          "download_time": current_datetime(),
+          "reached_interview_end": True,
+      },
+    )
   eviction_defender_download
+---
+code: |
+  snapshot_user_information_time = current_datetime()
+---
+code: |
+  snapshot_case_information_time = current_datetime()
+---
+code: |
+  snapshot_review_time = current_datetime()
+---
+code: |
+  snapshot_discovery_time = current_datetime()
 ---
 #################### Interview order #####################
 comment: |
@@ -117,6 +173,21 @@ code: |
   users[0].address.address
   users[0].address.geocode()
   users.gather()
+  store_variables_snapshot(
+    persistent=True,
+    data={
+        "start_time": start_time(),
+        "person_answering": showifdef("person_answering"),
+        "is_right_to_counsel": showifdef("is_right_to_counsel"),
+        "posting_warning": showifdef("posting_warning"),
+        "recommend_filing_answer": showifdef("recommend_filing_answer"),
+        "zip": showifdef("users[0].address.zip"),
+        "city": showifdef("users[0].address.city"),
+        "county": showifdef("users[0].address.county"),
+        "user_information_time": snapshot_user_information_time,
+        "reached_interview_end": False,
+    },
+  )
   
   ######### About your landlord
   nav.set_section("section_eviction_answer_other")
@@ -158,6 +229,22 @@ code: |
 
   ######### Claims and defenses
   set_progress(50)
+  store_variables_snapshot(
+    persistent=True,
+    data={
+        "start_time": start_time(),
+        "person_answering": showifdef("person_answering"),
+        "is_right_to_counsel": showifdef("is_right_to_counsel"),
+        "posting_warning": showifdef("posting_warning"),
+        "recommend_filing_answer": showifdef("recommend_filing_answer"),
+        "zip": showifdef("users[0].address.zip"),
+        "city": showifdef("users[0].address.city"),
+        "county": showifdef("users[0].address.county"),
+        "user_information_time": snapshot_user_information_time,
+        "case_information_time": snapshot_case_information_time,
+        "reached_interview_end": False,
+    },
+  )
   nav.set_section("section_eviction_answer_defenses")
   signpost_claims_and_defenses
   if got_notice_to_terminate:
@@ -511,6 +598,21 @@ code: |
 ---
 code: |
   motion_to_shorten_time_attachment.enabled = wants_discovery and not original_hearing_date_past
+---
+code: |
+  assembled_documents = list()
+  if "Answer" not in assembled_documents:
+    assembled_documents.append("Answer")
+  if "Instructions" not in assembled_documents:
+    assembled_documents.append("Instructions")
+  if eviction_motion_to_continue_attachment.enabled and "Motion to Continue" not in assembled_documents:
+    assembled_documents.append("Motion to Continue")
+  if eviction_motion_for_leave_attachment.enabled and "Motion for Leave" not in assembled_documents:
+    assembled_documents.append("Motion for Leave")
+  if eviction_discovery_attachment.enabled and "Discovery" not in assembled_documents:
+    assembled_documents.append("Discovery")
+  if motion_to_shorten_time_attachment.enabled and "Motion to Shorten Time" not in assembled_documents:
+    assembled_documents.append("Motion to Shorten Time")
 ---
 id: eviction answer determination code
 code: |

--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -46,15 +46,85 @@ code: |
 mandatory: True
 code: |
   al_intro_screen
-  store_variables_snapshot(persistent=True, data={"start_time": start_time(), "reached_interview_end": False})
+  track_intro
+
   eviction_defender_intro
   document_order
   nav.set_section("review_eviction_answer")
   review_eviction_answer
+  track_review
+
+  
+  nav.set_section("section_eviction_discovery")
+  precheck_items
+  
+  if wants_discovery:
+    customize_discovery_choice
+    if customize_discovery_choice == "customize_discovery":
+      customize_discovery_requests
+      review_discovery_requests
+  set_progress(90)
+  track_discovery
+
+  signpost_service_of_process
+  nav.set_section("section_eviction_answer_download")  
+  signature_date
+  if other_parties[0].service_method == "email":
+    other_parties[0].service_email
+  elif other_parties[0].service_method in ["mail", "hand"]:
+    other_parties[0].service_address.address
+
+  al_user_wants_reminders
+  set_progress(100)
+  store_variables_snapshot(
+      persistent=True,
+      data={
+          "start_time": start_time(timezone = 'America/Chicago'),
+          "person_answering": showifdef("person_answering"),
+          "is_right_to_counsel": showifdef("is_right_to_counsel"),
+          "posting_warning": showifdef("posting_warning"),
+          "recommend_filing_answer": showifdef("recommend_filing_answer"),
+          "zip": showifdef("users[0].address.zip"),
+          "city": showifdef("users[0].address.city"),
+          "county": showifdef("users[0].address.county"),
+          "user_information_time": snapshot_user_information_time,
+          "case_information_time": snapshot_case_information_time,
+          "review_time": snapshot_review_time,
+          "discovery_time": snapshot_discovery_time,
+          "assembled_documents": assembled_documents,
+          "download_time": current_datetime(timezone = 'America/Chicago'),
+          "reached_interview_end": True,
+      },
+    )
+  eviction_defender_download
+---
+code: |
+  snapshot_user_information_time = current_datetime(timezone = 'America/Chicago')
+---
+code: |
+  snapshot_case_information_time = current_datetime(timezone = 'America/Chicago')
+---
+code: |
+  snapshot_review_time = current_datetime(timezone = 'America/Chicago')
+---
+code: |
+  snapshot_discovery_time = current_datetime(timezone = 'America/Chicago')
+---
+code: |
+  store_variables_snapshot(
+    persistent=True, 
+    data={
+        "start_time": start_time(timezone = 'America/Chicago'),
+        "reached_interview_end": False,
+      },
+  )
+  track_intro = True
+---
+code: |
   store_variables_snapshot(
     persistent=True,
     data={
-        "start_time": start_time(),
+        "start_time": start_time(timezone = 'America/Chicago'),
         "person_answering": showifdef("person_answering"),
         "is_right_to_counsel": showifdef("is_right_to_counsel"),
         "posting_warning": showifdef("posting_warning"),
@@ -68,20 +138,13 @@ code: |
         "reached_interview_end": False
     },
   )
-  
-  nav.set_section("section_eviction_discovery")
-  precheck_items
-  
-  if wants_discovery:
-    customize_discovery_choice
-    if customize_discovery_choice == "customize_discovery":
-      customize_discovery_requests
-      review_discovery_requests
-  set_progress(90)
+  track_review = True
+---
+code: |
   store_variables_snapshot(
       persistent=True,
       data={
-          "start_time": start_time(),
+          "start_time": start_time(timezone = 'America/Chicago'),
           "person_answering": showifdef("person_answering"),
           "is_right_to_counsel": showifdef("is_right_to_counsel"),
           "posting_warning": showifdef("posting_warning"),
@@ -97,49 +160,44 @@ code: |
           "reached_interview_end": False,
       },
   )
-  signpost_service_of_process
-  nav.set_section("section_eviction_answer_download")  
-  signature_date
-  if other_parties[0].service_method == "email":
-    other_parties[0].service_email
-  elif other_parties[0].service_method in ["mail", "hand"]:
-    other_parties[0].service_address.address
-
-  al_user_wants_reminders
-  set_progress(100)
+  track_discovery = True
+---
+code: |
   store_variables_snapshot(
-      persistent=True,
-      data={
-          "start_time": start_time(),
-          "person_answering": showifdef("person_answering"),
-          "is_right_to_counsel": showifdef("is_right_to_counsel"),
-          "posting_warning": showifdef("posting_warning"),
-          "recommend_filing_answer": showifdef("recommend_filing_answer"),
-          "zip": showifdef("users[0].address.zip"),
-          "city": showifdef("users[0].address.city"),
-          "county": showifdef("users[0].address.county"),
-          "user_information_time": snapshot_user_information_time,
-          "case_information_time": snapshot_case_information_time,
-          "review_time": snapshot_review_time,
-          "discovery_time": snapshot_discovery_time,
-          "assembled_documents": assembled_documents,
-          "download_time": current_datetime(),
-          "reached_interview_end": True,
-      },
-    )
-  eviction_defender_download
+    persistent=True,
+    data={
+        "start_time": start_time(timezone = 'America/Chicago'),
+        "person_answering": showifdef("person_answering"),
+        "is_right_to_counsel": showifdef("is_right_to_counsel"),
+        "posting_warning": showifdef("posting_warning"),
+        "recommend_filing_answer": showifdef("recommend_filing_answer"),
+        "zip": showifdef("users[0].address.zip"),
+        "city": showifdef("users[0].address.city"),
+        "county": showifdef("users[0].address.county"),
+        "user_information_time": snapshot_user_information_time,
+        "reached_interview_end": False,
+    },
+  )
+  track_user_information = True
 ---
 code: |
-  snapshot_user_information_time = current_datetime()
----
-code: |
-  snapshot_case_information_time = current_datetime()
----
-code: |
-  snapshot_review_time = current_datetime()
----
-code: |
-  snapshot_discovery_time = current_datetime()
+  store_variables_snapshot(
+    persistent=True,
+    data={
+        "start_time": start_time(timezone = 'America/Chicago'),
+        "person_answering": showifdef("person_answering"),
+        "is_right_to_counsel": showifdef("is_right_to_counsel"),
+        "posting_warning": showifdef("posting_warning"),
+        "recommend_filing_answer": showifdef("recommend_filing_answer"),
+        "zip": showifdef("users[0].address.zip"),
+        "city": showifdef("users[0].address.city"),
+        "county": showifdef("users[0].address.county"),
+        "user_information_time": snapshot_user_information_time,
+        "case_information_time": snapshot_case_information_time,
+        "reached_interview_end": False,
+    },
+  )
+  track_case_information = True
 ---
 #################### Interview order #####################
 comment: |
@@ -173,21 +231,8 @@ code: |
   users[0].address.address
   users[0].address.geocode()
   users.gather()
-  store_variables_snapshot(
-    persistent=True,
-    data={
-        "start_time": start_time(),
-        "person_answering": showifdef("person_answering"),
-        "is_right_to_counsel": showifdef("is_right_to_counsel"),
-        "posting_warning": showifdef("posting_warning"),
-        "recommend_filing_answer": showifdef("recommend_filing_answer"),
-        "zip": showifdef("users[0].address.zip"),
-        "city": showifdef("users[0].address.city"),
-        "county": showifdef("users[0].address.county"),
-        "user_information_time": snapshot_user_information_time,
-        "reached_interview_end": False,
-    },
-  )
+  track_user_information
+
   
   ######### About your landlord
   nav.set_section("section_eviction_answer_other")
@@ -229,22 +274,8 @@ code: |
 
   ######### Claims and defenses
   set_progress(50)
-  store_variables_snapshot(
-    persistent=True,
-    data={
-        "start_time": start_time(),
-        "person_answering": showifdef("person_answering"),
-        "is_right_to_counsel": showifdef("is_right_to_counsel"),
-        "posting_warning": showifdef("posting_warning"),
-        "recommend_filing_answer": showifdef("recommend_filing_answer"),
-        "zip": showifdef("users[0].address.zip"),
-        "city": showifdef("users[0].address.city"),
-        "county": showifdef("users[0].address.county"),
-        "user_information_time": snapshot_user_information_time,
-        "case_information_time": snapshot_case_information_time,
-        "reached_interview_end": False,
-    },
-  )
+  track_case_information
+
   nav.set_section("section_eviction_answer_defenses")
   signpost_claims_and_defenses
   if got_notice_to_terminate:
@@ -600,19 +631,20 @@ code: |
   motion_to_shorten_time_attachment.enabled = wants_discovery and not original_hearing_date_past
 ---
 code: |
-  assembled_documents = list()
-  if "Answer" not in assembled_documents:
-    assembled_documents.append("Answer")
-  if "Instructions" not in assembled_documents:
-    assembled_documents.append("Instructions")
-  if eviction_motion_to_continue_attachment.enabled and "Motion to Continue" not in assembled_documents:
-    assembled_documents.append("Motion to Continue")
-  if eviction_motion_for_leave_attachment.enabled and "Motion for Leave" not in assembled_documents:
-    assembled_documents.append("Motion for Leave")
-  if eviction_discovery_attachment.enabled and "Discovery" not in assembled_documents:
-    assembled_documents.append("Discovery")
-  if motion_to_shorten_time_attachment.enabled and "Motion to Shorten Time" not in assembled_documents:
-    assembled_documents.append("Motion to Shorten Time")
+  assembled_documents_temp = list()
+  if "Answer" not in assembled_documents_temp:
+    assembled_documents_temp.append("Answer")
+  if "Instructions" not in assembled_documents_temp:
+    assembled_documents_temp.append("Instructions")
+  if eviction_motion_to_continue_attachment.enabled and "Motion to Continue" not in assembled_documents_temp:
+    assembled_documents_temp.append("Motion to Continue")
+  if eviction_motion_for_leave_attachment.enabled and "Motion for Leave" not in assembled_documents_temp:
+    assembled_documents_temp.append("Motion for Leave")
+  if eviction_discovery_attachment.enabled and "Discovery" not in assembled_documents_temp:
+    assembled_documents_temp.append("Discovery")
+  if motion_to_shorten_time_attachment.enabled and "Motion to Shorten Time" not in assembled_documents_temp:
+    assembled_documents_temp.append("Motion to Shorten Time")
+  assembled_documents = assembled_documents_temp
 ---
 id: eviction answer determination code
 code: |

--- a/docassemble/MOHUDEvictionProject/data/questions/shared.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/shared.yml
@@ -133,6 +133,11 @@ fields:
       - The tenant: tenant
       - An attorney: attorney
       - Someone **else** helping a tenant: tenant_helper
+  - Is this right to counsel?: is_right_to_counsel
+    datatype: yesnoradio
+    show if:
+      variable: person_answering
+      is: attorney
   - Will you file an appearance?: representation_type
     input type: radio
     choices:

--- a/docassemble/MOHUDEvictionProject/data/questions/shared.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/shared.yml
@@ -133,8 +133,8 @@ fields:
       - The tenant: tenant
       - An attorney: attorney
       - Someone **else** helping a tenant: tenant_helper
-  - Is this right to counsel?: is_right_to_counsel
-    datatype: yesnoradio
+  - This is a right to counsel case for an MO legal aid program: is_right_to_counsel
+    datatype: yesno
     show if:
       variable: person_answering
       is: attorney

--- a/docassemble/MOHUDEvictionProject/data/sources/interviews_run.feature
+++ b/docassemble/MOHUDEvictionProject/data/sources/interviews_run.feature
@@ -40,6 +40,7 @@ Scenario: MOHUDEvictionProject.yml attorney (entering appearance) runs
     | acknowledged_information_use['minimum_number'] | None | |
     | eviction_defender_intro | True | |
     | person_answering | attorney | person_answering |
+    | is_right_to_counsel | False | is_right_to_counsel |
     | representation_type | entering_appearance | representation_type |
     | users[0].name.first | Uli | users[0].name.first |
     | users[0].name.last | User1 | users[0].name.first |
@@ -67,6 +68,7 @@ Scenario: MOHUDEvictionProject.yml attorney (ghostwriting) runs
     | acknowledged_information_use['minimum_number'] | None | |
     | eviction_defender_intro | True | |
     | person_answering | attorney | person_answering |
+    | is_right_to_counsel | True | is_right_to_counsel |
     | representation_type | ghostwriting | representation_type |
     | users[0].name.first | Uli | users[0].name.first |
     | users[0].name.last | User1 | users[0].name.first |


### PR DESCRIPTION
…torney and updated analytics/statistics to include it. Fixed error related to selecting tenant instead of attorney and added defendant city and county to tracked stats.

LSEM requested that the right-to-counsel stats be tracked when an attorney fills out EDDE.

Fixed #556 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [X] Manually tested to ensure my PR is working
* [X] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [X] Requested review from Mia or Quinten
* [x] Ensured automated tests are passing
* [x] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
