### PR TITLE
Add interview stats and change interview order to remove casenet question

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -106,7 +106,7 @@ code: |
           "download_time": current_datetime(timezone = 'America/Chicago'),
           "discovery_to_final_duration": discovery_to_final_duration.minutes,
           "total_interview_duration": total_interview_duration.minutes,
-          "reached_interview_end": True,
+          "reached_interview_end": True
       },
     )
   eviction_defender_download
@@ -211,7 +211,7 @@ code: |
     persistent=True, 
     data={
         "start_time": start_time(timezone = 'America/Chicago'),
-        "reached_interview_end": False,
+        "reached_interview_end": False
       },
   )
   track_intro = True
@@ -224,11 +224,11 @@ code: |
         "person_answering": showifdef("person_answering"),
         "is_right_to_counsel": showifdef("is_right_to_counsel"),
         "posting_warning": showifdef("posting_warning"),
-        "recommend_filing_answer": showifdef("recommend_filing_answer"),
         "zip": showifdef("users[0].address.zip"),
         "city": showifdef("users[0].address.city"),
         "county": showifdef("users[0].address.county"),
         "user_information_time": snapshot_user_information_time,
+        "beginning_to_user_information_duration": beginning_to_user_information_duration.minutes,
         "reached_interview_end": False,
     },
   )
@@ -242,12 +242,15 @@ code: |
         "person_answering": showifdef("person_answering"),
         "is_right_to_counsel": showifdef("is_right_to_counsel"),
         "posting_warning": showifdef("posting_warning"),
-        "recommend_filing_answer": showifdef("recommend_filing_answer"),
         "zip": showifdef("users[0].address.zip"),
         "city": showifdef("users[0].address.city"),
         "county": showifdef("users[0].address.county"),
         "user_information_time": snapshot_user_information_time,
+        "beginning_to_user_information_duration": beginning_to_user_information_duration.minutes,
         "case_information_time": snapshot_case_information_time,
+        "user_to_case_information_duration": user_to_case_information_duration.minutes,
+        "case_type": case_type.true_values().elements,
+        "eviction_reason": eviction_reason.true_values().elements,
         "reached_interview_end": False,
     },
   )
@@ -261,13 +264,19 @@ code: |
         "person_answering": showifdef("person_answering"),
         "is_right_to_counsel": showifdef("is_right_to_counsel"),
         "posting_warning": showifdef("posting_warning"),
-        "recommend_filing_answer": showifdef("recommend_filing_answer"),
         "zip": showifdef("users[0].address.zip"),
         "city": showifdef("users[0].address.city"),
         "county": showifdef("users[0].address.county"),
         "user_information_time": snapshot_user_information_time,
+        "beginning_to_user_information_duration": beginning_to_user_information_duration.minutes,
         "case_information_time": snapshot_case_information_time,
+        "user_to_case_information_duration": user_to_case_information_duration.minutes,
+        "case_type": case_type.true_values().elements,
+        "eviction_reason": eviction_reason.true_values().elements,
         "review_time": snapshot_review_time,
+        "case_to_review_duration": case_to_review_duration.minutes,
+        "discovery_time": snapshot_discovery_time,
+        "defenses_list": defenses_list,
         "reached_interview_end": False
     },
   )
@@ -281,16 +290,22 @@ code: |
           "person_answering": showifdef("person_answering"),
           "is_right_to_counsel": showifdef("is_right_to_counsel"),
           "posting_warning": showifdef("posting_warning"),
-          "recommend_filing_answer": showifdef("recommend_filing_answer"),
           "zip": showifdef("users[0].address.zip"),
           "city": showifdef("users[0].address.city"),
           "county": showifdef("users[0].address.county"),
           "user_information_time": snapshot_user_information_time,
+          "beginning_to_user_information_duration": beginning_to_user_information_duration.minutes,
           "case_information_time": snapshot_case_information_time,
+          "user_to_case_information_duration": user_to_case_information_duration.minutes,
+          "case_type": case_type.true_values().elements,
+          "eviction_reason": eviction_reason.true_values().elements,
           "review_time": snapshot_review_time,
+          "case_to_review_duration": case_to_review_duration.minutes,
           "discovery_time": snapshot_discovery_time,
+          "defenses_list": defenses_list,
+          "review_to_discovery_duration": review_to_discovery_duration.minutes,
           "assembled_documents": assembled_documents,
-          "reached_interview_end": False,
+          "reached_interview_end": False
       },
   )
   track_discovery = True

--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -115,12 +115,6 @@ code: |
   snapshot_user_information_time = current_datetime(timezone = 'America/Chicago')
 ---
 code: |
-  case_type_list = case_type.true_values()
----
-code: |
-  eviction_reason_list = eviction_reason.true_values()
----
-code: |
   beginning_to_user_information_duration = date_difference(starting=start_time(timezone = 'America/Chicago'),ending = snapshot_user_information_time)
 ---
 code: |

--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -88,16 +88,24 @@ code: |
           "person_answering": showifdef("person_answering"),
           "is_right_to_counsel": showifdef("is_right_to_counsel"),
           "posting_warning": showifdef("posting_warning"),
-          "recommend_filing_answer": showifdef("recommend_filing_answer"),
           "zip": showifdef("users[0].address.zip"),
           "city": showifdef("users[0].address.city"),
           "county": showifdef("users[0].address.county"),
           "user_information_time": snapshot_user_information_time,
+          "beginning_to_user_information_duration": beginning_to_user_information_duration.minutes,
           "case_information_time": snapshot_case_information_time,
+          "user_to_case_information_duration": user_to_case_information_duration.minutes,
+          "case_type": case_type.true_values().elements,
+          "eviction_reason": eviction_reason.true_values().elements,
           "review_time": snapshot_review_time,
+          "case_to_review_duration": case_to_review_duration.minutes,
           "discovery_time": snapshot_discovery_time,
+          "defenses_list": defenses_list,
+          "review_to_discovery_duration": review_to_discovery_duration.minutes,
           "assembled_documents": assembled_documents,
           "download_time": current_datetime(timezone = 'America/Chicago'),
+          "discovery_to_final_duration": discovery_to_final_duration.minutes,
+          "total_interview_duration": total_interview_duration.minutes,
           "reached_interview_end": True,
       },
     )
@@ -107,13 +115,96 @@ code: |
   snapshot_user_information_time = current_datetime(timezone = 'America/Chicago')
 ---
 code: |
+  case_type_list = case_type.true_values()
+---
+code: |
+  eviction_reason_list = eviction_reason.true_values()
+---
+code: |
+  beginning_to_user_information_duration = date_difference(starting=start_time(timezone = 'America/Chicago'),ending = snapshot_user_information_time)
+---
+code: |
   snapshot_case_information_time = current_datetime(timezone = 'America/Chicago')
+---
+code: |
+  user_to_case_information_duration = date_difference(starting=snapshot_user_information_time,ending = snapshot_case_information_time)
 ---
 code: |
   snapshot_review_time = current_datetime(timezone = 'America/Chicago')
 ---
 code: |
+  case_to_review_duration = date_difference(starting=snapshot_case_information_time, ending = snapshot_review_time)
+---
+code: |
   snapshot_discovery_time = current_datetime(timezone = 'America/Chicago')
+---
+code: |
+  review_to_discovery_duration = date_difference(starting=snapshot_review_time, ending = snapshot_discovery_time)
+---
+code: |
+  discovery_to_final_duration = date_difference(starting=snapshot_discovery_time, ending = current_datetime(timezone = 'America/Chicago') )
+---
+code: |
+  total_interview_duration = date_difference(starting=start_time(timezone = 'America/Chicago'),ending = current_datetime(timezone = 'America/Chicago') )
+---
+id:  defense logic order
+comment: |
+  This can't be the best way to do this. Can a DADict act like a checkboxes dictionary?
+code: |
+  temp_defenses_list = list()
+  if defense_failure_to_terminate and "Failure to Terminate" not in temp_defenses_list:
+    temp_defenses_list.append("Failure to Terminate")
+  if defense_ud_no_written_notice and "No Notice" not in temp_defenses_list:
+    temp_defenses_list.append("No Notice")
+  if defense_ud_no_rental_period_notice and "Untimely Notice" not in temp_defenses_list:
+    temp_defenses_list.append("Untimely Notice")
+  if defense_ud_lease_requirements and "No Notice Required by Lease" not in temp_defenses_list:
+    temp_defenses_list.append("No Notice Required by Lease")
+  if defense_termination_notice_required_by_law and "No Notice Required by Law" not in temp_defenses_list:
+    temp_defenses_list.append("No Notice Required by Law")
+  if defense_ud_did_not_violate_lease and "No Violation of Lease" not in temp_defenses_list:
+    temp_defenses_list.append("No Violation of Lease")
+  if defense_ud_did_not_violate_lease and defense_no_breach and "No Breach" not in temp_defenses_list:
+    temp_defenses_list.append("No Breach")
+  if defense_ud_did_not_violate_lease and defense_breach_not_material and "Breach Not Material" not in temp_defenses_list:
+    temp_defenses_list.append("Breach Not Material")
+  if defense_discrimination and "Discrimination" not in temp_defenses_list:
+    temp_defenses_list.append("Discrimination")
+  if defense_reasonable_accommodation and "Failure to Provide Reasonable Accommodation" not in temp_defenses_list:
+    temp_defenses_list.append("Failure to Provide Reasonable Accommodation")
+  if defense_vawa and "VAWA Violation" not in temp_defenses_list:
+    temp_defenses_list.append("VAWA Violation")
+  if defense_rent_pleading_requirement and "Rent Pleading Requirement" not in temp_defenses_list:
+    temp_defenses_list.append("Rent Pleading Requirement")
+  if defense_lease_not_attached and "Lease Not Attached" not in temp_defenses_list:
+    temp_defenses_list.append("Lease Not Attached")
+  if defense_tender_refused and "Tender Refused" not in temp_defenses_list:
+    temp_defenses_list.append("Tender Refused")
+  if defense_rent_payment and "Rent Payment" not in temp_defenses_list:
+    temp_defenses_list.append("Rent Payment")
+  if defense_settlement and "Settlement" not in temp_defenses_list:
+    temp_defenses_list.append("Settlement")
+  if defense_lease_signed_under_duress and "Lease Signed Under Duress" not in temp_defenses_list:
+    temp_defenses_list.append("Lease Signed Under Duress")
+  if defense_fraud_lease and "Fraud in the inducement of the rental agreement" not in temp_defenses_list:
+    temp_defenses_list.append("Fraud in the inducement of the rental agreement")
+  if defense_liquidated_damages_late_fees and "Liquidated Damages Late Fees" not in temp_defenses_list:
+    temp_defenses_list.append("Liquidated Damages Late Fees")
+  if defense_estoppel_illegality and "Estoppel-Illegality" not in temp_defenses_list:
+    temp_defenses_list.append("Estoppel-Illegality")
+  if defense_breach_of_cqe and "Breach of CQE / privacy of tenant." not in temp_defenses_list:
+    temp_defenses_list.append("Breach of CQE / privacy of tenant.")
+  if defense_breach_of_habitability and "Breach Of Habitability" not in temp_defenses_list:
+    temp_defenses_list.append("Breach Of Habitability")
+  if defense_foreclosure and "Foreclosure" not in temp_defenses_list:
+    temp_defenses_list.append("Foreclosure")
+  if defense_new_owner_failed_to_provide_notice_of_sale and "New Owner Failed to Provide Notice of Sale" not in temp_defenses_list:
+    temp_defenses_list.append("New Owner Failed to Provide Notice of Sale")
+  if defense_unrepresented_corporation and "Unrepresented Corporation" not in temp_defenses_list:
+    temp_defenses_list.append("Unrepresented Corporation")
+  if defense_excessive_rent_for_subsidized_housing and "Excessive Rent for Subsidized Housing" not in temp_defenses_list:
+    temp_defenses_list.append("Excessive Rent for Subsidized Housing")
+  defenses_list = temp_defenses_list
 ---
 code: |
   store_variables_snapshot(
@@ -124,6 +215,43 @@ code: |
       },
   )
   track_intro = True
+---
+code: |
+  store_variables_snapshot(
+    persistent=True,
+    data={
+        "start_time": start_time(timezone = 'America/Chicago'),
+        "person_answering": showifdef("person_answering"),
+        "is_right_to_counsel": showifdef("is_right_to_counsel"),
+        "posting_warning": showifdef("posting_warning"),
+        "recommend_filing_answer": showifdef("recommend_filing_answer"),
+        "zip": showifdef("users[0].address.zip"),
+        "city": showifdef("users[0].address.city"),
+        "county": showifdef("users[0].address.county"),
+        "user_information_time": snapshot_user_information_time,
+        "reached_interview_end": False,
+    },
+  )
+  track_user_information = True
+---
+code: |
+  store_variables_snapshot(
+    persistent=True,
+    data={
+        "start_time": start_time(timezone = 'America/Chicago'),
+        "person_answering": showifdef("person_answering"),
+        "is_right_to_counsel": showifdef("is_right_to_counsel"),
+        "posting_warning": showifdef("posting_warning"),
+        "recommend_filing_answer": showifdef("recommend_filing_answer"),
+        "zip": showifdef("users[0].address.zip"),
+        "city": showifdef("users[0].address.city"),
+        "county": showifdef("users[0].address.county"),
+        "user_information_time": snapshot_user_information_time,
+        "case_information_time": snapshot_case_information_time,
+        "reached_interview_end": False,
+    },
+  )
+  track_case_information = True
 ---
 code: |
   store_variables_snapshot(
@@ -166,43 +294,6 @@ code: |
       },
   )
   track_discovery = True
----
-code: |
-  store_variables_snapshot(
-    persistent=True,
-    data={
-        "start_time": start_time(timezone = 'America/Chicago'),
-        "person_answering": showifdef("person_answering"),
-        "is_right_to_counsel": showifdef("is_right_to_counsel"),
-        "posting_warning": showifdef("posting_warning"),
-        "recommend_filing_answer": showifdef("recommend_filing_answer"),
-        "zip": showifdef("users[0].address.zip"),
-        "city": showifdef("users[0].address.city"),
-        "county": showifdef("users[0].address.county"),
-        "user_information_time": snapshot_user_information_time,
-        "reached_interview_end": False,
-    },
-  )
-  track_user_information = True
----
-code: |
-  store_variables_snapshot(
-    persistent=True,
-    data={
-        "start_time": start_time(timezone = 'America/Chicago'),
-        "person_answering": showifdef("person_answering"),
-        "is_right_to_counsel": showifdef("is_right_to_counsel"),
-        "posting_warning": showifdef("posting_warning"),
-        "recommend_filing_answer": showifdef("recommend_filing_answer"),
-        "zip": showifdef("users[0].address.zip"),
-        "city": showifdef("users[0].address.city"),
-        "county": showifdef("users[0].address.county"),
-        "user_information_time": snapshot_user_information_time,
-        "case_information_time": snapshot_case_information_time,
-        "reached_interview_end": False,
-    },
-  )
-  track_case_information = True
 ---
 #################### Interview order #####################
 comment: |

--- a/docassemble/MOHUDEvictionProject/data/questions/court_information.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/court_information.yml
@@ -227,6 +227,8 @@ subquestion: |
   
   [FILE MOSummonsType.png, 100%]
   
+  ${ collapse_template(find_case_type_example_template) }
+  
   % else: 
   Look at the "Case Header" Tab on Case.net to answer this question.
 
@@ -345,7 +347,7 @@ fields:
 ---
 template: find_case_type_example_template
 subject: |
-  Case.net case type example:
+  Where do I find the case type on Case.net?
 content: |
   [FILE CaseHeaderType.png, 100%]
 
@@ -437,7 +439,11 @@ code: |
 ---
 id: explain other case net uses
 question: |
-  Other information on Case.net
+  % if person_answering == "tenant":
+  Tracking your case on Case.net
+  % else:
+  Tracking the tenant's case on Case.net
+  % endif
 subquestion: |
   % if person_answering == "tenant":
   Keep a link to [Case.net](https://www.courts.mo.gov/cnet) so you can check it regularly.

--- a/docassemble/MOHUDEvictionProject/data/questions/shared.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/shared.yml
@@ -216,6 +216,8 @@ subquestion:  |
   % if tenant_got_summons and petition_available:
     If you have the {Summons} and {Petition}, the name of each {Plaintiff} is listed
     in the box labeled "Plaintiff".
+    
+    ${ collapse_template(find_other_plaintiffs_template) }
 
   % else:
     You can find the name of each {Plaintiff} in the Parties and Attorneys tab 
@@ -233,7 +235,11 @@ fields:
 ---
 Template: find_other_plaintiffs_template
 Subject: |
+  % if tenant_got_summons and petition_available:
+  How do I find out if there are other Plaintiffs on Case.net?
+  % else:
   How do I find out if there are other Plaintiffs?
+  % endif
 Content: |
   If there is more than one plaintiff, they will be listed directly below the first plaintiff.
   
@@ -252,6 +258,8 @@ subquestion: |
   
   [FILE MOSummonsPlaintiffAttorney.png, 100%]
   
+  ${ collapse_template(find_plaintiff_attorney_representation_template) }
+  
   % else:
     You can find out if the landlord is represented by an attorney in the Parties and Attorneys tab on Case.net.
   
@@ -264,7 +272,11 @@ fields:
 ---
 Template: find_plaintiff_attorney_representation_template
 Subject: |
+  % if tenant_got_summons and petition_available:
+  How do I find out if ${ other_parties[i] } is represented by an attorney using Case.net?
+  % else:
   How do I find out if ${ other_parties[i] } is represented by an attorney?
+  % endif
 Content: |
   If the landlord is represented by an attorney, then it will say "represented by" to the right of the landlord's name, and the attorney's name and address will be listed below.
   
@@ -288,6 +300,8 @@ subquestion: |
 
   ${ warn_picture_is_example_template }
   
+  ${ collapse_template(find_plaintiff_attorney_name_template) }
+  
   % else: 
   You can find the name and address of the attorney in the Parties and Attorneys tab on Case.net.
   
@@ -300,7 +314,11 @@ fields:
 ---
 Template: find_plaintiff_attorney_name_template
 Subject: |
+  % if tenant_got_summons and petition_available:
+  How do I find the name of ${ other_parties[i] }'s attorney on Case.net?
+  % else:
   How do I find the name of ${ other_parties[i] }'s attorney?
+  % endif
 Content: |
   If the landlord is represented by an attorney, then it will say "represented by" to the right of the landlord's name, and the attorney's name and address will be listed below.
   
@@ -353,6 +371,8 @@ subquestion: |
   
   [FILE MOSummonsHearingDate.png, 100%]
   
+  ${ collapse_template(find_original_hearing_on_casenet_template) }
+  
   % else:
     % if person_answering == "tenant":
     Using Case.net, you can find the time and date of your original court hearing on the "Scheduled Hearings and Trials" tab of your case.
@@ -378,10 +398,22 @@ fields:
 ---
 template: find_original_hearing_on_casenet_template
 subject: |
-  % if person_answering == "tenant":
-    How do I find the date and time of my original hearing?
+  % if tenant_got_summons and petition_available:
+  
+    % if person_answering == "tenant":
+    How do I find the date and time of my original hearing on Case.net?
+    % else:
+    How do I find the date and time of the tenant's original hearing on Case.net?
+    % endif
+  
   % else:
+  
+    % if person_answering == "tenant":
+    How do I find the date and time of my original hearing?
+    % else:
     How do I find the date and time of the tenant's original hearing?
+    % endif
+    
   % endif
 content: | 
   % if person_answering == "tenant":


### PR DESCRIPTION
<Type out your reasons for this PR>
This pull request involves two sets of changes that both affect the document interview order, so we combined them.

- Add interview stats
store_variable_snapshots are added throughout the interview order (in separate interview blocks to avoid duplication).  Code blocks are added to calculate the duration and lists used in the interviews.

- Remove question about casenet.
We got a couple pieces about feedback about adding the link to Case.net on the same page that we first introduce Case.net, and it seemed simpler to get rid of the question about using Case.net and provide information about using Case.net in accordions.  Now, if the user says the summons and petition are available, they will see on the screen instructions on where to find the information on the summons and an accordion will show how to find the information on Case.net.  If the user says the summons and petition are not available, they will see the Case.net instructions on the screen.
<Add links to any solved or related issues here>
fix #594 
fix #555 
fix #591
fix #413 

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [x] Manually tested to ensure my PR is working
* [x] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [x] Requested review from Mia or Quinten
* [ ] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
