### PR TITLE
got rid of users[0].attorney[0].name.first on review and used target_…

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/review.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/review.yml
@@ -395,10 +395,6 @@ review:
       % else:
       **None**
       % endif
-  - Edit: 
-      - users[0].attorney[0].name.first
-    button: |
-      Tenant's attorney: **${ users[0].attorney[0].name }**
   - Edit:
       - will_offer_payment
       - recompute:

--- a/docassemble/MOHUDEvictionProject/data/questions/shared.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/shared.yml
@@ -1295,7 +1295,7 @@ fields:
 
 ---
 code: |
-  if not users[0].attorney.there_are_any:
+  if users[0].attorney.target_number == 0:
     counsel_retained = False
   else:
     date_counsel_retained

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.MOHUDEvictionProject',
       url='https://motenanthelp.org/',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.AssemblyLine>=2.28.1'],
+      install_requires=['docassemble.AssemblyLine>=3.1.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MOHUDEvictionProject/', package='docassemble.MOHUDEvictionProject'),
      )


### PR DESCRIPTION
…number to define counsel_retained

<Type out your reasons for this PR>

Terry emailed about a bug - 

>  We assisted a pro se today at court. Pro se was holmesdina@gmail.com
> 
> She got through 90% of the interview (for Rent and Possession Answer & ADs, Motion for Leave, and Discovery), reviewed her answers, and we reached a page asking for "the date tenant hired you" or similar...as if an attorney was completing the interview, not a pro se.
> 
> There was no way around this page. She couldn't complete documents, and couldn't go back to fix it.  I added a message on the comment bubble of that page, it should be in your logs.
> 
> Bottom line: interview broke completely, and we don't know why. 
> 
>     Is there any chance you can figure this out in time for this lady to complete her documents?  
> 
> 
>     We never developed anything for attorneys to use the tool. Why was that last question even part of the interview? 

Because a motion to shorten time was appropriate, the interview tried to define counsel_retained, which was conditioned on users[0].attorney.there_are_any.  However, users[0].attorney uses .target_number.  I changed this condition of counsel_retained to the target_number (which will make it more likely the client can complete the interview from her saved answers).

There was an additional problem - the review block was setting users[0].attorney.there_are_any to true.  I removed the edit field in the review block for users[0].attorney[0].name.first.  I think we should use a table, but I just left it out for now, since Terry wants to prioritize getting the issue fixed for the client.


<Add links to any solved or related issues here>

### In this PR, I have:

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [x] Manually tested to ensure my PR is working
* [ ] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [x] Requested review from Mia or Quinten
* [ ] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
