### PR TITLE
removed discovery from interview order, attachment enabled and sections

### DIFF
--- a/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/MOHUDEvictionProject.yml
@@ -52,7 +52,6 @@ sections:
   - section_eviction_answer_tenancy: About your tenancy
   - section_eviction_answer_defenses: Claims and defenses
   - review_eviction_answer: Review your answers
-  - section_eviction_discovery: Discovery
   - section_eviction_answer_download: Download, print, deliver, and file
 ---
 language: es
@@ -65,7 +64,6 @@ sections:
   - section_eviction_answer_tenancy: Sobre su arrendamiento
   - section_eviction_answer_defenses: Reclamaciones y defensas
   - review_eviction_answer: Revisar sus respuestas
-  - section_eviction_discovery: Descubrimiento
   - section_eviction_answer_download: Descargar, imprimir, entregar y presentar  
 ---
 id: edde user role
@@ -96,16 +94,9 @@ code: |
   track_review
 
   
-  nav.set_section("section_eviction_discovery")
   precheck_items
   
-  if wants_discovery:
-    customize_discovery_choice
-    if customize_discovery_choice == "customize_discovery":
-      customize_discovery_requests
-      review_discovery_requests
-    if motion_to_shorten_time_attachment.enabled:
-      motion_to_shorten_time_order
+
   
   motions_for_hearing
   notice_of_hearing_attachment.enabled
@@ -834,11 +825,11 @@ code: |
 ---
 id: add eviction discovery if wants discovery
 code: |
-  eviction_discovery_attachment.enabled = wants_discovery and not motion_to_set_aside_attachment.enabled
+  eviction_discovery_attachment.enabled = False
 ---
 id: add motion to shorten time if wants discovery and hearing date in past 
 code: |
-  motion_to_shorten_time_attachment.enabled = wants_discovery and original_hearing_date_past and not final_judgment and trial_date_set
+  motion_to_shorten_time_attachment.enabled = False
 ---
 depends on:
   - final_judgment

--- a/docassemble/MOHUDEvictionProject/data/questions/shared.yml
+++ b/docassemble/MOHUDEvictionProject/data/questions/shared.yml
@@ -1544,7 +1544,7 @@ subquestion: |
   
   **4. Complete and {file} the forms:**
   
-    * Fill in the date you deliver each form to the other party in the "Certificate of Service" box usually at the end of the document. There are 3 Certificate of Service boxes in the discovery document that you will need to fill in before delivering to the other party. 
+    * Fill in the date you deliver each form to the other party in the "Certificate of Service" box usually at the end of the document. 
     
     % if not docket_number: 
     * Add the case number.

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.MOHUDEvictionProject',
       url='https://motenanthelp.org/',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.AssemblyLine>=3.1.0'],
+      install_requires=['docassemble.AssemblyLine>=3.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MOHUDEvictionProject/', package='docassemble.MOHUDEvictionProject'),
      )


### PR DESCRIPTION
<Type out your reasons for this PR>
Email from Terry
During the standard interview to create the answer/affirmative defense pleading, the user can trigger the creation of written discovery simply by answering one question about wanting more information from opponent.  As it is, this causes confusion and too many people creating discovery they don't really need. Worse, we have gotten reports of some users filing discovery as part of the answer and defenses. This should not be the case. We need discovery to be a separate interview, meaning the user starts with the intention of creating discovery. If this is not feasible to fix quickly, then at the very least,can someone relatively quickly remove the "branch" logic that allows launching the discovery creation interview questions? Better to not have the ability to create written discovery at all, than to have that portion working poorly. 

<Add links to any solved or related issues here>

### In this PR, I have:
I removed the mentions of the discovery from the interview order, the sections, and the attachment enabling code.

<Check these boxes below before making the PR>
<To turn the box into a checkbox add an X inside it like this [X]>
<Remove spaces from the checkboxes so it's like this [X] not this [X ]>
<To Preview what your PR will look like, select "Preview" above>

* [x] Manually tested to ensure my PR is working
* [ ] Ensured issues that this PR closes will be [automatically closed](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [x] Requested review from Mia or Quinten
* [ ] Ensured automated tests are passing
* [ ] Updated automated tests so they are now passing
* [ ] There were no automated tests on this repo so I filled out [this interview](https://apps-dev.suffolklitlab.org/run/test-setup/) and there is now an "it runs" test
